### PR TITLE
Feat/remove dot net prompt option

### DIFF
--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -14,7 +14,6 @@ var templateDataManager = require('../templateDataManager');
 var errorHandler = require('../errorHandler');
 var utils = require('../utils');
 var Spinner = require('cli-spinner').Spinner;
-var projectTypes = require('../projectTypeConfig');
 
 var _log;
 var _promptAnswers;

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -110,11 +110,6 @@ function getCopyExcludeList() {
 		'node_modules'
 	];
 
-	if(_promptAnswers.projectType === projectTypes.dotnet) {
-		excludeList.push('views');
-		excludeList.push('release.js');
-	}
-
 	return excludeList;
 }
 

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -168,7 +168,7 @@ function installNpmPackages() {
 
 	var projectModulesArr = _promptAnswers.cartridgeModules;
 
-	if(_promptAnswers.projectType === projectTypes.nodejs) {
+	if(_promptAnswers.isNodejsSite) {
 		projectModulesArr.push('cartridge-node-server');
 	}
 

--- a/bin/projectTypeConfig.js
+++ b/bin/projectTypeConfig.js
@@ -1,4 +1,0 @@
-module.exports = {
-    'static': 'Static Website',
-    'nodejs': 'Node.js Server'
-};

--- a/bin/projectTypeConfig.js
+++ b/bin/projectTypeConfig.js
@@ -1,1 +1,4 @@
-module.exports = {'dotnet': 'Dot NET', 'static': 'Static Website', 'nodejs': 'Node.js Server'};
+module.exports = {
+    'static': 'Static Website',
+    'nodejs': 'Node.js Server'
+};

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -70,7 +70,6 @@ function getProjectTypePromptOptions() {
 		name: 'projectType',
 		message: 'What is the project type?',
 		choices: [
-			projectTypes.dotnet,
 			projectTypes.static,
 			projectTypes.nodejs
 		]

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -35,7 +35,7 @@ function setPromptOptionsData(moduleList) {
 	_promptOptions.push(getProjectNamePromptOptions());
 	_promptOptions.push(getProjectAuthorPromptOptions());
 	_promptOptions.push(getProjectDescriptionPromptOptions());
-	_promptOptions.push(getProjectTypePromptOptions());
+	_promptOptions.push(getIfProjectIsNodejsSite());
 	_promptOptions.push(getCartridgeModulesPromptOptions(moduleList));
 	_promptOptions.push(getUserConfirmCopyPromptOptions());
 
@@ -64,7 +64,7 @@ function extractModuleNames(values) {
 	return moduleNames;
 }
 
-function getProjectTypePromptOptions() {
+function getIfProjectIsNodejsSite() {
 	return {
 		type: 'confirm',
 		name: 'isNodejsSite',

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -32,10 +32,10 @@ promptOptionsApi.getNewCommandPromptOptions = function() {
 }
 
 function setPromptOptionsData(moduleList) {
-	_promptOptions.push(getProjectTypePromptOptions());
 	_promptOptions.push(getProjectNamePromptOptions());
 	_promptOptions.push(getProjectAuthorPromptOptions());
 	_promptOptions.push(getProjectDescriptionPromptOptions());
+	_promptOptions.push(getProjectTypePromptOptions());
 	_promptOptions.push(getCartridgeModulesPromptOptions(moduleList));
 	_promptOptions.push(getUserConfirmCopyPromptOptions());
 
@@ -66,13 +66,10 @@ function extractModuleNames(values) {
 
 function getProjectTypePromptOptions() {
 	return {
-		type: 'list',
-		name: 'projectType',
-		message: 'What is the project type?',
-		choices: [
-			projectTypes.static,
-			projectTypes.nodejs
-		]
+		type: 'confirm',
+		name: 'isNodejsSite',
+		message: 'Is the project using Node.js server-side? (This will install a blank Node.js server setup)',
+		default: false
 	}
 }
 

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -6,7 +6,6 @@ var chalk = require('chalk');
 var utils = require('./utils');
 var errorHandler = require('./errorHandler');
 var modulePromptsOptions = require('./promptModuleOptions');
-var projectTypes = require('./projectTypeConfig');
 
 var _promptOptions = [];
 var _log;


### PR DESCRIPTION
## Remove the 'DotNet' option

The project type prompt has also been changed to instead of asking what project type the user is generating it now asks if if they are using node.js for the server side. 

This was changed primarily as removing the 'DotNet' option for the project type left 'Static Site' and 'Node.js server' options. A project built with a CMS such as Umbraco would come under neither option and could cause confusion. Changing the text to be 'Static Site / CMS' could also come under the umbrella of a node.js site if using a CMS such as Ghost.

I enclose two images of what the CLI prompts currently are and what they have been changed to

### How it currently is
![old-nodejs-prompt](https://cloud.githubusercontent.com/assets/4798861/15114767/6c8e41f0-15f3-11e6-809a-59690df57622.png)

### What it will be changed to
![new-nodejs-prompt](https://cloud.githubusercontent.com/assets/4798861/15114775/7511e732-15f3-11e6-8e2d-e24df2a5c37d.png)

