### PR TITLE
fix: Change registry to be the main npm registry. Nodejitsu registry …

### DIFF
--- a/bin/promptModuleOptions.js
+++ b/bin/promptModuleOptions.js
@@ -1,7 +1,10 @@
 "use strict";
 
 var Registry = require('npm-registry');
-var npm = new Registry({ retries: 4 });
+var npm = new Registry({
+	registry: 'http://registry.npmjs.org',
+	retries: 4
+});
 var inArray = require('in-array');
 
 var utils = require('./utils');


### PR DESCRIPTION
The `npm-registry` module uses Nodejitsu's npm registry by default. This (and a whole heap of other mirrors) are 404'ing, and can't be accessed.

This was then erroring and preventing cartridge installations AT ALL! This code is to explicitly change the registry to the main Joyent npm URL. Getting this in and released will 'fix' cartridge, which is currently broken at the installation stage.

Work down the line could be done to add mirrors (options key to `npm-registry`) but I could only find 1 or 2 mirrors that actually worked :/