### PR TITLE
Feat/remove uneeded template files post install

### DIFF
--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -133,13 +133,15 @@ function getTemplateFileList() {
 	// Creds file
 	fileList.push({
 		src:  path.join(TEMPLATE_FILES_PATH, 'creds.tpl'),
-		dest: path.join(CURRENT_WORKING_DIR, '_config', 'creds.json')
+		dest: path.join(CURRENT_WORKING_DIR, '_config', 'creds.json'),
+		deleteSrcFile: true
 	});
 
 	// Project package file
 	fileList.push({
 		src:  path.join(TEMPLATE_FILES_PATH, 'package.tpl'),
-		dest: path.join(CURRENT_WORKING_DIR, 'package.json')
+		dest: path.join(CURRENT_WORKING_DIR, 'package.json'),
+		deleteSrcFile: true
 	});
 
 	// Project readme

--- a/bin/fileTemplater.js
+++ b/bin/fileTemplater.js
@@ -42,31 +42,39 @@ function templateFile(templateFileConfig) {
     var compiled;
     var output;
 
-    fs.readFile(templateFileConfig.src, 'utf8', function(err, fileContents) {
+    fs.readFile(templateFileConfig.src, 'utf8', function readFileCallback(err, fileContents) {
         if (err) errorHandler(err);
 
         compiled = template(fileContents);
         output = compiled(_config.data);
 
-        fs.writeFile(templateFileConfig.dest, output, 'utf8', function(err) {
-            if (err) errorHandler(err);
-
-            _config.onEachFile(templateFileConfig.dest);
-
-            if(templateFileConfig.deleteSrcFile) {
-              fs.unlinkSync(templateFileConfig.src);
-            }
-
-            if(_fileNumber === _config.files.length) {
-                _config = _defaultConfig;
-                _config.onCompleted();
-            }
-
-            _fileNumber++;
-
-        });
-
+        writeTemplatedContents(templateFileConfig, output);
     });
+}
+
+/**
+ * Write compiled result to destination file
+ * @param  {Object} fileConfig     Individual file config object
+ * @param  {String} compiledOutput The compiled output from the template file
+ */
+function writeTemplatedContents(fileConfig, compiledOutput) {
+  fs.writeFile(fileConfig.dest, compiledOutput, 'utf8', function writeFileCallback(err) {
+      if (err) errorHandler(err);
+
+      _config.onEachFile(fileConfig.dest);
+
+      if(fileConfig.deleteSrcFile) {
+        fs.unlinkSync(fileConfig.src);
+      }
+
+      if(_fileNumber === _config.files.length) {
+          _config = _defaultConfig;
+          _config.onCompleted();
+      }
+
+      _fileNumber++;
+
+  });
 }
 
 module.exports = fileTemplaterApi;

--- a/bin/fileTemplater.js
+++ b/bin/fileTemplater.js
@@ -36,22 +36,26 @@ fileTemplaterApi.setConfig = function(config) {
 /**
  * Template a single file.
  * Get the contents of a file, template it and re-write to the same file
- * @param  {Object} filePaths File paths data, containing file src and dest
+ * @param  {Object} templateFileConfig Config data, containing template file config
  */
-function templateFile(filePaths) {
+function templateFile(templateFileConfig) {
     var compiled;
     var output;
 
-    fs.readFile(filePaths.src, 'utf8', function(err, fileContents) {
+    fs.readFile(templateFileConfig.src, 'utf8', function(err, fileContents) {
         if (err) errorHandler(err);
 
         compiled = template(fileContents);
         output = compiled(_config.data);
 
-        fs.writeFile(filePaths.dest, output, 'utf8', function(err) {
+        fs.writeFile(templateFileConfig.dest, output, 'utf8', function(err) {
             if (err) errorHandler(err);
 
-            _config.onEachFile(filePaths.dest);
+            _config.onEachFile(templateFileConfig.dest);
+
+            if(templateFileConfig.deleteSrcFile) {
+              fs.unlinkSync(templateFileConfig.src);
+            }
 
             if(_fileNumber === _config.files.length) {
                 _config = _defaultConfig;

--- a/test/fileTemplaterSpec.js
+++ b/test/fileTemplaterSpec.js
@@ -77,6 +77,12 @@ describe('As a user of the file templater module', function() {
 			templateFileJson.answer.should.equal(templateData.answer)
 		})
 
+    it('should have not deleted source files when `deleteSrcFile` is not provided', function() {
+      var srcTemplateFile = path.join(TEST_TEMP_DIR, 'creds.tpl');
+
+      srcTemplateFile.should.be.a.path();
+    })
+
 		it('should have called the onCompleted callback once', function() {
 			onCompletedSpy.calledOnce.should.be.true;
 		})
@@ -104,8 +110,15 @@ describe('As a user of the file templater module', function() {
 
 			fileList.push({
 				src: path.join(TEST_TEMP_DIR, 'creds-again.tpl'),
-				dest: path.join(TEST_TEMP_DIR, 'creds-again-templated.json')
+				dest: path.join(TEST_TEMP_DIR, 'creds-again-templated.json'),
+        deleteSrcFile: false
 			})
+
+      fileList.push({
+        src: path.join(TEST_TEMP_DIR, 'fileToBeDeleted.tpl'),
+        dest: path.join(TEST_TEMP_DIR, 'fileToBeDeleted-templated.json'),
+        deleteSrcFile: true
+      })
 
 			fileTemplater.setConfig({
 				data: templateData,
@@ -126,8 +139,26 @@ describe('As a user of the file templater module', function() {
 		})
 
 		it('should have called the onEachFile callback twice', function() {
-			onEachFileSpy.calledTwice.should.be.true;
+			onEachFileSpy.calledThrice.should.be.true;
 		})
+
+    it('should have not deleted source files when `deleteSrcFile` is not provided', function() {
+      var srcTemplateFile = path.join(TEST_TEMP_DIR, 'creds.tpl');
+
+      srcTemplateFile.should.be.a.path();
+    })
+
+    it('should have not deleted source files when `deleteSrcFile` is set to false', function() {
+      var srcTemplateFile = path.join(TEST_TEMP_DIR, 'creds-again.tpl');
+
+      srcTemplateFile.should.be.a.path();
+    })
+
+    it('should have deleted `fileToBeDeleted.tpl` when `deleteSrcFile` is set to true', function() {
+      var srcTemplateFile = path.join(TEST_TEMP_DIR, 'fileToBeDeleted.tpl');
+
+      srcTemplateFile.should.not.be.a.path();
+    })
 
 	})
 })

--- a/test/fileTemplaterSpec.js
+++ b/test/fileTemplaterSpec.js
@@ -4,7 +4,7 @@ var os = require('os');
 var fs = require('fs-extra');
 var path = require('path');
 
-var fileTemplater =  require('../bin/fileTemplater');
+var fileTemplater = require('../bin/fileTemplater');
 
 chai.use(require('chai-fs'));
 chai.should();
@@ -13,9 +13,9 @@ var TEST_TEMP_DIR = path.join(os.tmpdir(), 'file-templater');
 
 
 function changeToOsTempDirAndCopyFixtures() {
-    fs.ensureDirSync(TEST_TEMP_DIR);
-    fs.copySync(path.resolve('./', 'test', 'fixtures', 'templateFiles'), TEST_TEMP_DIR);
-    process.chdir(TEST_TEMP_DIR);
+	fs.ensureDirSync(TEST_TEMP_DIR);
+	fs.copySync(path.resolve('./', 'test', 'fixtures', 'templateFiles'), TEST_TEMP_DIR);
+	process.chdir(TEST_TEMP_DIR);
 }
 
 function tearDown() {
@@ -30,24 +30,24 @@ function getTemplateData() {
 }
 
 describe('As a user of the file templater module', function() {
-    before(changeToOsTempDirAndCopyFixtures);
-    after(tearDown)
+	before(changeToOsTempDirAndCopyFixtures);
+	after(tearDown)
 
-    describe('When templating one file', function() {
+	describe('When templating one file', function() {
 
-    	var onCompletedSpy = sinon.spy();
-    	var onEachFileSpy = sinon.spy();
+		var onCompletedSpy = sinon.spy();
+		var onEachFileSpy = sinon.spy();
 
-    	var templateData = getTemplateData();
+		var templateData = getTemplateData();
 
-    	var fileList = [];
+		var fileList = [];
 
-    	before(function(done) {
+		before(function(done) {
 
-    		fileList.push({
-    			src: path.join(TEST_TEMP_DIR, 'creds.tpl'),
-    			dest: path.join(TEST_TEMP_DIR, 'creds-templated.json')
-    		})
+			fileList.push({
+				src: path.join(TEST_TEMP_DIR, 'creds.tpl'),
+				dest: path.join(TEST_TEMP_DIR, 'creds-templated.json')
+			})
 
 			fileTemplater.setConfig({
 				data: templateData,
@@ -61,51 +61,51 @@ describe('As a user of the file templater module', function() {
 			})
 
 			fileTemplater.run();
-    	})
+		})
 
-        it('should correctly create the templated file', function() {
-        	var templatedFilePath = path.join(TEST_TEMP_DIR, 'creds-templated.json');
+		it('should correctly create the templated file', function() {
+			var templatedFilePath = path.join(TEST_TEMP_DIR, 'creds-templated.json');
 
-        	templatedFilePath.should.be.a.file();
-        })
+			templatedFilePath.should.be.a.file();
+		})
 
-        it('should correctly template the contents with template data', function() {
-        	var templatedFilePath = path.join(TEST_TEMP_DIR, 'creds-templated.json');
-        	var templateFileContents = fs.readFileSync(templatedFilePath, 'utf8');
-        	var templateFileJson = JSON.parse(templateFileContents);
+		it('should correctly template the contents with template data', function() {
+			var templatedFilePath = path.join(TEST_TEMP_DIR, 'creds-templated.json');
+			var templateFileContents = fs.readFileSync(templatedFilePath, 'utf8');
+			var templateFileJson = JSON.parse(templateFileContents);
 
-        	templateFileJson.answer.should.equal(templateData.answer)
-        })
+			templateFileJson.answer.should.equal(templateData.answer)
+		})
 
-        it('should have called the onCompleted callback once', function() {
-        	onCompletedSpy.calledOnce.should.be.true;
-        })
+		it('should have called the onCompleted callback once', function() {
+			onCompletedSpy.calledOnce.should.be.true;
+		})
 
-        it('shoudl have called the onEachFile callback once', function() {
-        	onEachFileSpy.calledOnce.should.be.true;
-        })
+		it('should have called the onEachFile callback once', function() {
+			onEachFileSpy.calledOnce.should.be.true;
+		})
 
-    })
+	})
 
-    describe('When templating multiple files', function() {
-    	var onCompletedSpy = sinon.spy();
-    	var onEachFileSpy = sinon.spy();
+	describe('When templating multiple files', function() {
+		var onCompletedSpy = sinon.spy();
+		var onEachFileSpy = sinon.spy();
 
-    	var templateData = getTemplateData();
+		var templateData = getTemplateData();
 
-    	var fileList = [];
+		var fileList = [];
 
-    	before(function(done) {
+		before(function(done) {
 
-    		fileList.push({
-    			src: path.join(TEST_TEMP_DIR, 'creds.tpl'),
-    			dest: path.join(TEST_TEMP_DIR, 'creds-templated.json')
-    		})
+			fileList.push({
+				src: path.join(TEST_TEMP_DIR, 'creds.tpl'),
+				dest: path.join(TEST_TEMP_DIR, 'creds-templated.json')
+			})
 
-    		fileList.push({
-    			src: path.join(TEST_TEMP_DIR, 'creds-again.tpl'),
-    			dest: path.join(TEST_TEMP_DIR, 'creds-again-templated.json')
-    		})
+			fileList.push({
+				src: path.join(TEST_TEMP_DIR, 'creds-again.tpl'),
+				dest: path.join(TEST_TEMP_DIR, 'creds-again-templated.json')
+			})
 
 			fileTemplater.setConfig({
 				data: templateData,
@@ -119,15 +119,15 @@ describe('As a user of the file templater module', function() {
 			})
 
 			fileTemplater.run();
-    	})
+		})
 
-        it('should have called the onCompleted callback once', function() {
-        	onCompletedSpy.calledOnce.should.be.true;
-        })
+		it('should have called the onCompleted callback once', function() {
+			onCompletedSpy.calledOnce.should.be.true;
+		})
 
-        it('should have called the onEachFile callback twice', function() {
-        	onEachFileSpy.calledTwice.should.be.true;
-        })
+		it('should have called the onEachFile callback twice', function() {
+			onEachFileSpy.calledTwice.should.be.true;
+		})
 
-    })
+	})
 })

--- a/test/fileTemplaterSpec.js
+++ b/test/fileTemplaterSpec.js
@@ -77,7 +77,7 @@ describe('As a user of the file templater module', function() {
 			templateFileJson.answer.should.equal(templateData.answer)
 		})
 
-    it('should have not deleted source files when `deleteSrcFile` is not provided', function() {
+    it('should not delete source file when `deleteSrcFile` is not provided', function() {
       var srcTemplateFile = path.join(TEST_TEMP_DIR, 'creds.tpl');
 
       srcTemplateFile.should.be.a.path();
@@ -142,19 +142,19 @@ describe('As a user of the file templater module', function() {
 			onEachFileSpy.calledThrice.should.be.true;
 		})
 
-    it('should have not deleted source files when `deleteSrcFile` is not provided', function() {
+    it('should not deleted source file when `deleteSrcFile` is not provided', function() {
       var srcTemplateFile = path.join(TEST_TEMP_DIR, 'creds.tpl');
 
       srcTemplateFile.should.be.a.path();
     })
 
-    it('should have not deleted source files when `deleteSrcFile` is set to false', function() {
+    it('should not delete source file when `deleteSrcFile` is set to false', function() {
       var srcTemplateFile = path.join(TEST_TEMP_DIR, 'creds-again.tpl');
 
       srcTemplateFile.should.be.a.path();
     })
 
-    it('should have deleted `fileToBeDeleted.tpl` when `deleteSrcFile` is set to true', function() {
+    it('should delete `fileToBeDeleted.tpl` when `deleteSrcFile` is set to true', function() {
       var srcTemplateFile = path.join(TEST_TEMP_DIR, 'fileToBeDeleted.tpl');
 
       srcTemplateFile.should.not.be.a.path();

--- a/test/fixtures/templateFiles/fileToBeDeleted.tpl
+++ b/test/fixtures/templateFiles/fileToBeDeleted.tpl
@@ -1,0 +1,1 @@
+//This isn't the file you're looking for


### PR DESCRIPTION
After a cartridge installation, the files `creds.tpl` and `package.tpl` file are no longer needed and can be deleted (the remaining three files are used when installing expansion packs for updating readme etc). Addtions have been added to `fileTemplater` to make it configurable to delete template `src` file after templating has been completed. 

With this change, the tests have been updated to check if a file is deleted when it should be and not deleted when it shouldn't be. 

Apologises for some of the diffs, indentation in the test file was off :/