### PR TITLE
Feat/base install option

### DIFF
--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -18,6 +18,7 @@ var Spinner = require('cli-spinner').Spinner;
 var _log;
 var _promptAnswers;
 var _options;
+var _isBaseInstall;
 
 var CURRENT_WORKING_DIR = process.cwd();
 var TEMPLATE_FILES_PATH = path.join(CURRENT_WORKING_DIR, '_cartridge');
@@ -26,7 +27,7 @@ var newCommandApi = {};
 
 newCommandApi.init = function(options, baseInstall) {
 	_options = options;
-	_options.baseInstall = baseInstall;
+	_isBaseInstall = baseInstall;
 
 	_log = utils.getLogInstance(_options);
 
@@ -46,12 +47,17 @@ function preSetup() {
 }
 
 function setupOnScreenPrompts() {
-	promptOptions
-		.getNewCommandPromptOptions()
-	 	.then(function(promptOptions) {
-	 		console.log('');
-	 		inquirer.prompt(promptOptions, promptCallback);
- 		})
+
+	if(_isBaseInstall) {
+		//@TODO - base install specific code here
+	} else {
+		promptOptions
+			.getNewCommandPromptOptions()
+			.then(function(promptOptions) {
+				console.log('');
+				inquirer.prompt(promptOptions, promptCallback);
+			})
+	}
 }
 
 function promptCallback(answers) {

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -47,31 +47,37 @@ function preSetup() {
 }
 
 function setupOnScreenPrompts() {
-
 	if(_isBaseInstall) {
-		_log.warn('');
-
-		_log.warn(chalk.bold('This will create a cartridge project that has:'));
-		_log.info(' · Sass setup');
-		_log.info(' · JavaScript setup');
-		_log.info(' · A local server');
-		_log.info(' · Ability to copy static assets');
-		_log.warn('');
-
-		inquirer.prompt(promptOptions.getConfirmationPrompt(), function(answers) {
-			if(answers.userHasConfirmed) {
-				console.log('@TODO - DO THE BASE INSTALL');
-			}
-		});
-		
+		runBaseInstall();
 	} else {
-		promptOptions
-			.getNewCommandPromptOptions()
-			.then(function(promptOptions) {
-				console.log('');
-				inquirer.prompt(promptOptions, promptCallback);
-			})
+		runCompleteInstall();
 	}
+}
+
+function runBaseInstall() {
+	_log.warn('');
+
+	_log.warn(chalk.bold('This will create a cartridge project that has:'));
+	_log.info(' · Sass setup');
+	_log.info(' · JavaScript setup');
+	_log.info(' · A local server');
+	_log.info(' · Ability to copy static assets');
+	_log.warn('');
+
+	inquirer.prompt(promptOptions.getConfirmationPrompt(), function(answers) {
+		if(answers.userHasConfirmed) {
+			console.log('@TODO - DO THE BASE INSTALL');
+		}
+	});
+}
+
+function runCompleteInstall() {
+	promptOptions
+		.getNewCommandPromptOptions()
+		.then(function(promptOptions) {
+			console.log('');
+			inquirer.prompt(promptOptions, promptCallback);
+		})
 }
 
 function promptCallback(answers) {
@@ -83,6 +89,7 @@ function promptCallback(answers) {
 		_log.info('');
 		_log.info('Inserting the cartridge...');
 
+		//@TODO - THIS WILL NEED TO BE EXTRACTED IN OWN METHOD
 		releaseService
 			.downloadLatestRelease(_options)
 			.then(copyCartridgeSourceFilesToCwd)

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -6,6 +6,7 @@ var fs       = require('fs-extra');
 var path     = require('path');
 
 var npmInstallPackage = require('npm-install-package')
+var emoji = require('node-emoji');
 
 var releaseService = require('../releaseService');
 var fileTemplater = require('../fileTemplater');
@@ -101,7 +102,7 @@ function promptCallback(answers) {
 	if(_promptAnswers.userHasConfirmed === true) {
 
 		_log.info('');
-		_log.info('Inserting the cartridge...');
+		_log.info(emoji.get('joystick') + '  Inserting the cartridge...');
 
 		//@TODO - THIS MAY NEED TO BE EXTRACTED IN OWN METHOD
 		releaseService
@@ -109,7 +110,7 @@ function promptCallback(answers) {
 			.then(copyCartridgeSourceFilesToCwd)
 
 	} else {
-		_log.info('User cancelled - no files copied')
+		_log.info(emoji.get('x') + '  User cancelled - no files copied')
 	}
 }
 
@@ -157,7 +158,7 @@ function getCopyExcludeList() {
 
 function templateCopiedFiles() {
 	_log.debug('');
-	_log.info('Booting up files...');
+	_log.info(emoji.get('floppy_disk') +'  Booting up files...');
 
 	//@TODO - LOOK AT MAKING FILE TEMPLATER PROMISE BASED
 	fileTemplater.setConfig({
@@ -255,7 +256,7 @@ function finishSetup() {
 	_log.info(chalk.green('Setup complete!'));
 	_log.info('Cartridge project ' + chalk.yellow(_promptAnswers.projectName) + ' has been installed!');
 	_log.info('');
-	_log.info('Final steps:');
+	_log.info(emoji.get('bulb') + '  Final steps:');
 	_log.info(' · Run ' + chalk.yellow('npm install') + ' to download all project dependencies. (If this fails you may need to run ' + chalk.yellow('sudo npm install') + ')');
 	_log.info(' · Run ' + chalk.yellow('gulp') + ' for initial setup of styles and scripts.');
 	_log.info(' · Run ' + chalk.yellow('gulp watch') + ' to setup watching of files.');

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -64,11 +64,23 @@ function runBaseInstall() {
 	_log.info(' · Ability to copy static assets');
 	_log.warn('');
 
-	inquirer.prompt(promptOptions.getBaseInstallPrompt(), function(answers) {
-		answers.cartridgeModules = ['cartridge-sass', 'cartridge-javascript', 'cartridge-local-server', 'cartridge-copy-assets'];
+	promptOptions
+		.getBaseInstallPromptData()
+		.then(function(promptOptions) {
+			inquirer.prompt(promptOptions, function(answers) {
 
-		promptCallback(answers);
-	});
+				answers.cartridgeModules = ['cartridge-sass', 'cartridge-javascript','cartridge-copy-assets'];
+
+				if(answers.isNodejsSite === true) {
+					answers.cartridgeModules.push('cartridge-node-server')
+				} else {
+					answers.cartridgeModules.push('cartridge-static-html');
+					answers.cartridgeModules.push('cartridge-local-server');
+				}
+
+				promptCallback(answers);
+			});
+		})
 }
 
 function runCompleteInstall() {

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -49,7 +49,20 @@ function preSetup() {
 function setupOnScreenPrompts() {
 
 	if(_isBaseInstall) {
-		//@TODO - base install specific code here
+		_log.warn('');
+
+		_log.warn(chalk.bold('Running through a base install. This will create a cartridge project that has:'));
+		_log.info(' · Sass setup');
+		_log.info(' · JavaScript setup');
+		_log.info(' · A local server');
+		_log.info(' · Ability to copy static assets');
+		_log.warn('');
+
+		inquirer.prompt(promptOptions.getConfirmationPrompt(), function(answers) {
+			console.log('@TODO - DO THE BASE INSTALL');
+		});
+
+		//can reuse promptOptions.getUserConfirmCopyPromptOptions
 	} else {
 		promptOptions
 			.getNewCommandPromptOptions()

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -51,7 +51,7 @@ function setupOnScreenPrompts() {
 	if(_isBaseInstall) {
 		_log.warn('');
 
-		_log.warn(chalk.bold('Running through a base install. This will create a cartridge project that has:'));
+		_log.warn(chalk.bold('This will create a cartridge project that has:'));
 		_log.info(' · Sass setup');
 		_log.info(' · JavaScript setup');
 		_log.info(' · A local server');

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -64,10 +64,10 @@ function runBaseInstall() {
 	_log.info(' · Ability to copy static assets');
 	_log.warn('');
 
-	inquirer.prompt(promptOptions.getConfirmationPrompt(), function(answers) {
-		if(answers.userHasConfirmed) {
-			console.log('@TODO - DO THE BASE INSTALL');
-		}
+	inquirer.prompt(promptOptions.getBaseInstallPrompt(), function(answers) {
+		answers.cartridgeModules = ['cartridge-sass', 'cartridge-javascript', 'cartridge-local-server', 'cartridge-copy-assets'];
+
+		promptCallback(answers);
 	});
 }
 
@@ -82,6 +82,9 @@ function runCompleteInstall() {
 
 function promptCallback(answers) {
 	_promptAnswers = answers;
+
+	// console.log(answers);
+
 	templateDataManager.setData(answers);
 
 	if(_promptAnswers.userHasConfirmed) {

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -123,7 +123,9 @@ function templateCopiedFiles() {
 		basePath: CURRENT_WORKING_DIR,
 		files: getTemplateFileList(),
 		onEachFile: singleFileCallback,
-		onCompleted: installNpmPackages
+		onCompleted: function() {
+			installNpmPackages(_promptAnswers.cartridgeModules)
+		}
 	})
 
 	fileTemplater.run();
@@ -165,17 +167,15 @@ function singleFileCallback(templateFilePath) {
 	_log.debug('Templating file -', templateFilePath);
 }
 
-function installNpmPackages() {
+function installNpmPackages(packages) {
 	var spinner = new Spinner('%s');
 	spinner.setSpinnerString('|/-\\');
 
-	var projectModulesArr = _promptAnswers.cartridgeModules;
-
 	if(_promptAnswers.isNodejsSite) {
-		projectModulesArr.push('cartridge-node-server');
+		packages.push('cartridge-node-server');
 	}
 
-	if(_promptAnswers.cartridgeModules.length > 0) {
+	if(packages.length > 0) {
 		console.log('');
 		_log.info('Installing expansion packs...');
 
@@ -183,7 +183,7 @@ function installNpmPackages() {
 			spinner.start();
 		}
 
-		npmInstallPackage(_promptAnswers.cartridgeModules, { saveDev: true }, function(err) {
+		npmInstallPackage(packages, { saveDev: true }, function(err) {
 			if (err) errorHandler(err);
 
 			if(_log.getLevel() <= 2) {

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -61,8 +61,8 @@ function runBaseInstall() {
 	_log.warn(chalk.bold('This will create a cartridge project that has:'));
 	_log.info(' · Sass setup');
 	_log.info(' · JavaScript setup');
-	_log.info(' · A local server');
-	_log.info(' · Ability to copy static assets');
+	_log.info(' · Server setup');
+	_log.info(' · Copy over static assets etc. fonts');
 	_log.warn('');
 
 	promptOptions
@@ -104,7 +104,6 @@ function promptCallback(answers) {
 		_log.info('');
 		_log.info(emoji.get('joystick') + '  Inserting the cartridge...');
 
-		//@TODO - THIS MAY NEED TO BE EXTRACTED IN OWN METHOD
 		releaseService
 			.downloadLatestRelease(_options)
 			.then(copyCartridgeSourceFilesToCwd)

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -179,14 +179,14 @@ function installNpmPackages(packages) {
 		console.log('');
 		_log.info('Installing expansion packs...');
 
-		if(_log.getLevel() <= 2) {
+		if(_log.getLevel() <= _log.levels.INFO) {
 			spinner.start();
 		}
 
 		npmInstallPackage(packages, { saveDev: true }, function(err) {
 			if (err) errorHandler(err);
 
-			if(_log.getLevel() <= 2) {
+			if(_log.getLevel() <= _log.levels.INFO) {
 				spinner.stop(true);
 			}
 

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -47,7 +47,7 @@ function preSetup() {
 }
 
 function setupOnScreenPrompts() {
-	if(_isBaseInstall) {
+	if(_isBaseInstall === true) {
 		runBaseInstall();
 	} else {
 		runCompleteInstall();
@@ -98,7 +98,7 @@ function promptCallback(answers) {
 
 	templateDataManager.setData(answers);
 
-	if(_promptAnswers.userHasConfirmed) {
+	if(_promptAnswers.userHasConfirmed === true) {
 
 		_log.info('');
 		_log.info('Inserting the cartridge...');
@@ -126,12 +126,12 @@ function fileCopyFilter(path) {
 	for (var i = 0; i < filesDirsToExclude.length; i++) {
 		//Check if needToCopyFile is still true and
 		//hasn't been flipped during loop
-		if(needToCopyFile) {
+		if(needToCopyFile === true) {
 			needToCopyFile = path.indexOf(filesDirsToExclude[i]) === -1;
 		}
 	};
 
-	if(!needToCopyFile) {
+	if(needToCopyFile === false) {
 		_log.debug(chalk.underline('Skipping path - ' + path));
 	} else {
 		_log.debug('Copying path  -', path);
@@ -213,7 +213,7 @@ function installNpmPackages(packages) {
 	var spinner = new Spinner('%s');
 	spinner.setSpinnerString('|/-\\');
 
-	if(_promptAnswers.isNodejsSite) {
+	if(_promptAnswers.isNodejsSite === true) {
 		packages.push('cartridge-node-server');
 	}
 

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -59,10 +59,11 @@ function setupOnScreenPrompts() {
 		_log.warn('');
 
 		inquirer.prompt(promptOptions.getConfirmationPrompt(), function(answers) {
-			console.log('@TODO - DO THE BASE INSTALL');
+			if(answers.userHasConfirmed) {
+				console.log('@TODO - DO THE BASE INSTALL');
+			}
 		});
-
-		//can reuse promptOptions.getUserConfirmCopyPromptOptions
+		
 	} else {
 		promptOptions
 			.getNewCommandPromptOptions()
@@ -77,7 +78,7 @@ function promptCallback(answers) {
 	_promptAnswers = answers;
 	templateDataManager.setData(answers);
 
-	if(_promptAnswers.isOkToCopyFiles) {
+	if(_promptAnswers.userHasConfirmed) {
 
 		_log.info('');
 		_log.info('Inserting the cartridge...');

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -67,20 +67,21 @@ function runBaseInstall() {
 	promptOptions
 		.getBaseInstallPromptData()
 		.then(function(promptOptions) {
-			inquirer.prompt(promptOptions, function(answers) {
-
-				answers.cartridgeModules = ['cartridge-sass', 'cartridge-javascript','cartridge-copy-assets'];
-
-				if(answers.isNodejsSite === true) {
-					answers.cartridgeModules.push('cartridge-node-server')
-				} else {
-					answers.cartridgeModules.push('cartridge-static-html');
-					answers.cartridgeModules.push('cartridge-local-server');
-				}
-
-				promptCallback(answers);
-			});
+			inquirer.prompt(promptOptions, handleBaseInstallPromptData);
 		})
+}
+
+function handleBaseInstallPromptData(answers) {
+	answers.cartridgeModules = ['cartridge-sass', 'cartridge-javascript','cartridge-copy-assets'];
+
+	if(answers.isNodejsSite === true) {
+		answers.cartridgeModules.push('cartridge-node-server')
+	} else {
+		answers.cartridgeModules.push('cartridge-static-html');
+		answers.cartridgeModules.push('cartridge-local-server');
+	}
+
+	promptCallback(answers);
 }
 
 function runCompleteInstall() {

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -83,8 +83,6 @@ function runCompleteInstall() {
 function promptCallback(answers) {
 	_promptAnswers = answers;
 
-	// console.log(answers);
-
 	templateDataManager.setData(answers);
 
 	if(_promptAnswers.userHasConfirmed) {
@@ -92,7 +90,7 @@ function promptCallback(answers) {
 		_log.info('');
 		_log.info('Inserting the cartridge...');
 
-		//@TODO - THIS WILL NEED TO BE EXTRACTED IN OWN METHOD
+		//@TODO - THIS MAY NEED TO BE EXTRACTED IN OWN METHOD
 		releaseService
 			.downloadLatestRelease(_options)
 			.then(copyCartridgeSourceFilesToCwd)
@@ -148,6 +146,7 @@ function templateCopiedFiles() {
 	_log.debug('');
 	_log.info('Booting up files...');
 
+	//@TODO - LOOK AT MAKING FILE TEMPLATER PROMISE BASED
 	fileTemplater.setConfig({
 		data: templateDataManager.getData(),
 		basePath: CURRENT_WORKING_DIR,

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -159,18 +159,16 @@ function templateCopiedFiles() {
 	_log.debug('');
 	_log.info(emoji.get('floppy_disk') +'  Booting up files...');
 
-	//@TODO - LOOK AT MAKING FILE TEMPLATER PROMISE BASED
-	fileTemplater.setConfig({
-		data: templateDataManager.getData(),
-		basePath: CURRENT_WORKING_DIR,
-		files: getTemplateFileList(),
-		onEachFile: singleFileCallback,
-		onCompleted: function() {
+	fileTemplater()
+		.run({
+			data: templateDataManager.getData(),
+			basePath: CURRENT_WORKING_DIR,
+			files: getTemplateFileList(),
+			onEachFile: singleFileCallback
+		})
+		.then(function() {
 			installNpmPackages(_promptAnswers.cartridgeModules)
-		}
-	})
-
-	fileTemplater.run();
+		})
 }
 
 function getTemplateFileList() {

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -62,7 +62,7 @@ function runBaseInstall() {
 	_log.info(' · Sass setup');
 	_log.info(' · JavaScript setup');
 	_log.info(' · Server setup');
-	_log.info(' · Copy over static assets etc. fonts');
+	_log.info(' · Copy over static assets fonts etc');
 	_log.warn('');
 
 	promptOptions

--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -24,8 +24,10 @@ var TEMPLATE_FILES_PATH = path.join(CURRENT_WORKING_DIR, '_cartridge');
 
 var newCommandApi = {};
 
-newCommandApi.init = function(options) {
+newCommandApi.init = function(options, baseInstall) {
 	_options = options;
+	_options.baseInstall = baseInstall;
+
 	_log = utils.getLogInstance(_options);
 
 	preSetup();
@@ -128,7 +130,7 @@ function templateCopiedFiles() {
 }
 
 function getTemplateFileList() {
-	var fileList      = [];
+	var fileList = [];
 
 	// Creds file
 	fileList.push({

--- a/bin/fileTemplater.js
+++ b/bin/fileTemplater.js
@@ -5,34 +5,6 @@ var template = require('lodash/template');
 
 var errorHandler = require('./errorHandler');
 
-// TWO PUBLIC METHODS
-// - .setConfig()
-//    - sets the template data
-//    - base path
-//    - files to template
-//    - on each file (this will have to be done here, due to promises)
-//    - on completed will be the .then() of the promise, not needed!!!
-//
-//  - .run()
-//    - this sets the templating in motion, using the provided config\
-//
-//  WONDER IF THE .setConfig() can be integrated into the run() call
-//  e.g.
-//
-//  .run(configOptions)
-//  .then(function() {
-//     console.log('finished templating')
-//  })
-//
-//  have to new up an instance? etc
-//  var Templater = require('templater');
-//  var templater = Templater.create();
-//
-//  templater
-//    .run(options)
-//    .then(function() {
-//    })
-
 function fileTemplater() {
 
   var config = {};

--- a/bin/fileTemplater.js
+++ b/bin/fileTemplater.js
@@ -1,5 +1,3 @@
-"use strict";
-
 var fs = require('fs');
 var path = require('path');
 var extend = require('extend');
@@ -7,74 +5,105 @@ var template = require('lodash/template');
 
 var errorHandler = require('./errorHandler');
 
-var _fileNumber = 1;
-var _defaultConfig = {
-    onEachFile: function() {},
-    onCompleted: function() {}
-}
+// TWO PUBLIC METHODS
+// - .setConfig()
+//    - sets the template data
+//    - base path
+//    - files to template
+//    - on each file (this will have to be done here, due to promises)
+//    - on completed will be the .then() of the promise, not needed!!!
+//
+//  - .run()
+//    - this sets the templating in motion, using the provided config\
+//
+//  WONDER IF THE .setConfig() can be integrated into the run() call
+//  e.g.
+//
+//  .run(configOptions)
+//  .then(function() {
+//     console.log('finished templating')
+//  })
+//
+//  have to new up an instance? etc
+//  var Templater = require('templater');
+//  var templater = Templater.create();
+//
+//  templater
+//    .run(options)
+//    .then(function() {
+//    })
 
-var _config;
+function fileTemplater() {
 
-var fileTemplaterApi = {};
+  var config = {};
+  var defaultConfig = {
+    data: {},
+    basePath: process.cwd(),
+    files: [],
+    onEachFile: function() {}
+  }
 
-/**
- * Run file templating
- */
-fileTemplaterApi.run = function() {
-    _config.files.forEach(function(element, index, array) {
-        templateFile(element);
+  function run(userConfig) {
+    var filesToRead = [];
+    config = extend(defaultConfig, userConfig);
+
+    for (var i = 0; i < config.files.length; i++) {
+      filesToRead.push(readFile(config.files[i]));
+    }
+
+    return Promise.all(filesToRead)
+      .then(writeToAllFiles)
+  }
+
+  function writeToAllFiles(filesData) {
+    var templatedFiles = [];
+
+    for (var i = 0; i < filesData.length; i++) {
+      templatedFiles.push(writeToFile(filesData[i]));
+    }
+
+    return Promise.all(templatedFiles);
+  }
+
+  function writeToFile(fileConfig) {
+    return new Promise(function(resolve, reject) {
+
+      fs.writeFile(fileConfig.config.dest, fileConfig.output, 'utf8', function writeFileCallback(err) {
+          if (err) reject(err);
+
+          config.onEachFile(fileConfig.config.dest);
+
+          if(fileConfig.config.deleteSrcFile) {
+            fs.unlinkSync(fileConfig.config.src);
+          }
+
+          resolve();
+      });
     });
+  }
+
+  function readFile(templateFileConfig) {
+    return new Promise(function(resolve, reject) {
+      var compiled;
+      var output;
+
+      fs.readFile(templateFileConfig.src, 'utf8', function readFileCallback(err, fileContents) {
+          if (err) reject(err);
+
+          compiled = template(fileContents);
+          output = compiled(config.data);
+
+          resolve({
+            config: templateFileConfig,
+            output: output
+          });
+      });
+    })
+  }
+
+  return {
+    run: run
+  }
 }
 
-/**
- * Sets internal config object
- */
-fileTemplaterApi.setConfig = function(config) {
-    _config = extend(_defaultConfig, config);
-}
-
-/**
- * Template a single file.
- * Get the contents of a file, template it and re-write to the same file
- * @param  {Object} templateFileConfig Config data, containing template file config
- */
-function templateFile(templateFileConfig) {
-    var compiled;
-    var output;
-
-    fs.readFile(templateFileConfig.src, 'utf8', function readFileCallback(err, fileContents) {
-        if (err) errorHandler(err);
-
-        compiled = template(fileContents);
-        output = compiled(_config.data);
-
-        writeTemplatedContents(templateFileConfig, output);
-    });
-}
-
-/**
- * Write compiled result to destination file
- * @param  {Object} fileConfig     Individual file config object
- * @param  {String} compiledOutput The compiled output from the template file
- */
-function writeTemplatedContents(fileConfig, compiledOutput) {
-  fs.writeFile(fileConfig.dest, compiledOutput, 'utf8', function writeFileCallback(err) {
-      if (err) errorHandler(err);
-
-      _config.onEachFile(fileConfig.dest);
-
-      if(fileConfig.deleteSrcFile) {
-        fs.unlinkSync(fileConfig.src);
-      }
-
-      if(_fileNumber === _config.files.length) {
-          _config = _defaultConfig;
-          _config.onCompleted();
-      }
-
-      _fileNumber++;
-
-  });
-}
-
-module.exports = fileTemplaterApi;
+module.exports = fileTemplater;

--- a/bin/programBuilder.js
+++ b/bin/programBuilder.js
@@ -21,13 +21,11 @@ module.exports = function() {
  */
 function setNewCommand() {
 	program
-		.command('new [env]')
+		.command('new [baseInstall]')
 		.description('Create a new project (on-screen wizard)')
 		.option("-B, --base", "Use the base install pre-set")
 		.action(function(env, options) {
-			//console.log('Base install mode: ', options.base)
-
-			newCommand.init(getProgramOptions());
+			newCommand.init(getProgramOptions(), options.base);
 		});
 }
 

--- a/bin/programBuilder.js
+++ b/bin/programBuilder.js
@@ -21,9 +21,12 @@ module.exports = function() {
  */
 function setNewCommand() {
 	program
-		.command('new')
+		.command('new [env]')
 		.description('Create a new project (on-screen wizard)')
-		.action(function() {
+		.option("-B, --base", "Use the base install pre-set")
+		.action(function(env, options) {
+			//console.log('Base install mode: ', options.base)
+
 			newCommand.init(getProgramOptions());
 		});
 }

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -29,25 +29,39 @@ promptOptionsApi.getNewCommandPromptOptions = function() {
 		})
 }
 
-promptOptionsApi.getBaseInstallPrompt = function() {
-	return [
+promptOptionsApi.getBaseInstallPromptData = function() {
+	_log.debug('');
+	_log.debug('Getting base install prompt options data');
+
+	return Promise.resolve([
 		getProjectNamePromptOptions(),
 		getProjectAuthorPromptOptions(),
 		getProjectDescriptionPromptOptions(),
+		getIfProjectIsNodejsSite(),
 		getUserConfirmCopyPromptOptions()
-	];
+	]);
 }
 
 function setPromptOptionsData(moduleList) {
 	return Promise.resolve([
-		getProjectNamePromptOptions()),
-		getProjectAuthorPromptOptions()),
-		getProjectDescriptionPromptOptions()),
-		getIfProjectIsNodejsSite()),
-		getCartridgeModulesPromptOptions(moduleList)),
-		getUserConfirmCopyPromptOptions())
+		getProjectNamePromptOptions(),
+		getProjectAuthorPromptOptions(),
+		getProjectDescriptionPromptOptions(),
+		getIfProjectIsNodejsSite(),
+		getCartridgeModulesPromptOptions(moduleList),
+		getUserConfirmCopyPromptOptions()
 	]);
 }
+
+// function getProjectServerSetupPromptOptions() {
+// 	return {
+// 		type: 'list',
+// 		name: 'baseInstallServerModule',
+// 		message: 'What server setup do you need?',
+// 		choices: ['cartridge-local-server', 'cartridge-node-server'],
+// 		default: 0
+// 	}
+// }
 
 function getCartridgeModulesPromptOptions(moduleData) {
 	return {

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -6,6 +6,7 @@ var chalk = require('chalk');
 var utils = require('./utils');
 var errorHandler = require('./errorHandler');
 var modulePromptsOptions = require('./promptModuleOptions');
+var emoji = require('node-emoji')
 
 var _log;
 
@@ -57,7 +58,7 @@ function getCartridgeModulesPromptOptions(moduleData) {
 	return {
 		type: 'checkbox',
 		name: 'cartridgeModules',
-		message: 'What modules would you like included?',
+		message: emoji.get('star') + '  What modules would you like included?',
 		choices: moduleData,
 		filter: extractModuleNames
 	}
@@ -79,7 +80,7 @@ function getIfProjectIsNodejsSite() {
 	return {
 		type: 'confirm',
 		name: 'isNodejsSite',
-		message: 'Is the project using Node.js server-side? (This will install a blank Node.js server setup)',
+		message: emoji.get('sparkles') + '  Is the project using Node.js server-side? (This will install a blank Node.js server setup)',
 		default: false
 	}
 }
@@ -88,7 +89,7 @@ function getProjectNamePromptOptions() {
 	return {
 		type: 'input',
 		name: 'projectName',
-		message: 'What is the project name?',
+		message: emoji.get('blue_book')  + '  What is the project name?',
 		validate: function(value) { return inputNotEmpty(value, 'Project Name'); },
 	}
 }
@@ -97,7 +98,7 @@ function getProjectAuthorPromptOptions() {
 	return {
 		type: 'input',
 		name: 'projectAuthor',
-		message: 'Who is the author of the project?',
+		message: emoji.get('sleuth_or_spy') + '  Who is the author of the project?',
 		validate: function(value) { return inputNotEmpty(value, 'Author'); },
 		filter: function(value) { return titleize(value); }
 	}
@@ -107,7 +108,7 @@ function getProjectDescriptionPromptOptions() {
 	return {
 		type: 'input',
 		name: 'projectDescription',
-		message: 'What is the project description?',
+		message: emoji.get('pencil2') + '  What is the project description?',
 		default: function () { return ''; }
 	}
 }
@@ -116,7 +117,7 @@ function getUserConfirmCopyPromptOptions() {
 	return {
 		type: 'confirm',
 		name: 'userHasConfirmed',
-		message: 'Ready to start setup! Press enter to confirm',
+		message: emoji.get('warning') + '  Ready to start setup! Press enter to confirm',
 		default: true
 	}
 }

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -7,7 +7,6 @@ var utils = require('./utils');
 var errorHandler = require('./errorHandler');
 var modulePromptsOptions = require('./promptModuleOptions');
 
-var _promptOptions = [];
 var _log;
 
 var promptOptionsApi = {};
@@ -40,14 +39,14 @@ promptOptionsApi.getBaseInstallPrompt = function() {
 }
 
 function setPromptOptionsData(moduleList) {
-	_promptOptions.push(getProjectNamePromptOptions());
-	_promptOptions.push(getProjectAuthorPromptOptions());
-	_promptOptions.push(getProjectDescriptionPromptOptions());
-	_promptOptions.push(getIfProjectIsNodejsSite());
-	_promptOptions.push(getCartridgeModulesPromptOptions(moduleList));
-	_promptOptions.push(getUserConfirmCopyPromptOptions());
-
-	return Promise.resolve(_promptOptions);
+	return Promise.resolve([
+		getProjectNamePromptOptions()),
+		getProjectAuthorPromptOptions()),
+		getProjectDescriptionPromptOptions()),
+		getIfProjectIsNodejsSite()),
+		getCartridgeModulesPromptOptions(moduleList)),
+		getUserConfirmCopyPromptOptions())
+	]);
 }
 
 function getCartridgeModulesPromptOptions(moduleData) {

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -30,6 +30,10 @@ promptOptionsApi.getNewCommandPromptOptions = function() {
 		})
 }
 
+promptOptionsApi.getConfirmationPrompt = function() {
+	return [getUserConfirmCopyPromptOptions()];
+}
+
 function setPromptOptionsData(moduleList) {
 	_promptOptions.push(getProjectNamePromptOptions());
 	_promptOptions.push(getProjectAuthorPromptOptions());

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -30,8 +30,13 @@ promptOptionsApi.getNewCommandPromptOptions = function() {
 		})
 }
 
-promptOptionsApi.getConfirmationPrompt = function() {
-	return [getUserConfirmCopyPromptOptions()];
+promptOptionsApi.getBaseInstallPrompt = function() {
+	return [
+		getProjectNamePromptOptions(),
+		getProjectAuthorPromptOptions(),
+		getProjectDescriptionPromptOptions(),
+		getUserConfirmCopyPromptOptions()
+	];
 }
 
 function setPromptOptionsData(moduleList) {

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -107,7 +107,7 @@ function getProjectDescriptionPromptOptions() {
 function getUserConfirmCopyPromptOptions() {
 	return {
 		type: 'confirm',
-		name: 'isOkToCopyFiles',
+		name: 'userHasConfirmed',
 		message: 'Ready to start setup! Press enter to confirm',
 		default: true
 	}

--- a/bin/promptOptions.js
+++ b/bin/promptOptions.js
@@ -53,16 +53,6 @@ function setPromptOptionsData(moduleList) {
 	]);
 }
 
-// function getProjectServerSetupPromptOptions() {
-// 	return {
-// 		type: 'list',
-// 		name: 'baseInstallServerModule',
-// 		message: 'What server setup do you need?',
-// 		choices: ['cartridge-local-server', 'cartridge-node-server'],
-// 		default: 0
-// 	}
-// }
-
 function getCartridgeModulesPromptOptions(moduleData) {
 	return {
 		type: 'checkbox',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "inquirer": "^0.11.4",
     "lodash": "^4.0.1",
     "loglevel": "^1.4.0",
+    "node-emoji": "^1.5.1",
     "npm-install-package": "^1.0.2",
     "npm-registry": "^0.1.13",
     "pretty-error": "^2.0.0",

--- a/test/fileTemplaterSpec.js
+++ b/test/fileTemplaterSpec.js
@@ -11,7 +11,6 @@ chai.should();
 
 var TEST_TEMP_DIR = path.join(os.tmpdir(), 'file-templater');
 
-
 function changeToOsTempDirAndCopyFixtures() {
 	fs.ensureDirSync(TEST_TEMP_DIR);
 	fs.copySync(path.resolve('./', 'test', 'fixtures', 'templateFiles'), TEST_TEMP_DIR);
@@ -35,11 +34,8 @@ describe('As a user of the file templater module', function() {
 
 	describe('When templating one file', function() {
 
-		var onCompletedSpy = sinon.spy();
 		var onEachFileSpy = sinon.spy();
-
 		var templateData = getTemplateData();
-
 		var fileList = [];
 
 		before(function(done) {
@@ -49,18 +45,14 @@ describe('As a user of the file templater module', function() {
 				dest: path.join(TEST_TEMP_DIR, 'creds-templated.json')
 			})
 
-			fileTemplater.setConfig({
+			fileTemplater().run({
 				data: templateData,
 				basePath: process.cwd(),
 				files: fileList,
-				onEachFile: onEachFileSpy,
-				onCompleted: function() {
-					done();
-					onCompletedSpy();
-				}
+				onEachFile: onEachFileSpy
+			}).then(function() {
+				done();
 			})
-
-			fileTemplater.run();
 		})
 
 		it('should correctly create the templated file', function() {
@@ -83,10 +75,6 @@ describe('As a user of the file templater module', function() {
       srcTemplateFile.should.be.a.path();
     })
 
-		it('should have called the onCompleted callback once', function() {
-			onCompletedSpy.calledOnce.should.be.true;
-		})
-
 		it('should have called the onEachFile callback once', function() {
 			onEachFileSpy.calledOnce.should.be.true;
 		})
@@ -94,11 +82,9 @@ describe('As a user of the file templater module', function() {
 	})
 
 	describe('When templating multiple files', function() {
-		var onCompletedSpy = sinon.spy();
+
 		var onEachFileSpy = sinon.spy();
-
 		var templateData = getTemplateData();
-
 		var fileList = [];
 
 		before(function(done) {
@@ -120,25 +106,17 @@ describe('As a user of the file templater module', function() {
         deleteSrcFile: true
       })
 
-			fileTemplater.setConfig({
+			fileTemplater().run({
 				data: templateData,
 				basePath: process.cwd(),
 				files: fileList,
-				onEachFile: onEachFileSpy,
-				onCompleted: function() {
-					done();
-					onCompletedSpy();
-				}
+				onEachFile: onEachFileSpy
+			}).then(function() {
+				done();
 			})
-
-			fileTemplater.run();
 		})
 
-		it('should have called the onCompleted callback once', function() {
-			onCompletedSpy.calledOnce.should.be.true;
-		})
-
-		it('should have called the onEachFile callback twice', function() {
+		it('should have called the onEachFile callback thrice', function() {
 			onEachFileSpy.calledThrice.should.be.true;
 		})
 
@@ -161,4 +139,5 @@ describe('As a user of the file templater module', function() {
     })
 
 	})
+
 })

--- a/test/fixtures/DotNetNoDescription.js
+++ b/test/fixtures/DotNetNoDescription.js
@@ -3,5 +3,5 @@ module.exports = {
     projectName: 'test project',
     projectAuthor: 'test author',
     projectDescription: '',
-    isOkToCopyFiles: true
+    userHasConfirmed: true
 }

--- a/test/fixtures/StaticNoDescription.js
+++ b/test/fixtures/StaticNoDescription.js
@@ -3,5 +3,5 @@ module.exports = {
     projectName: 'dfdsfds',
     projectAuthor: 'Dsfsdf',
     projectDescription: '',
-    isOkToCopyFiles: true
+    userHasConfirmed: true
 }


### PR DESCRIPTION
This adds in the functionality of a cartridge base install.

Running `cartridge new --base` will no longer ask the user which modules should be installed. Instead it will ask all previous questions (project name, author) and install a set of pre-determined set of modules, along with a node or local server - which has it's own user prompt.

This will allow for a quick installation of a project using the modules that are used the most.

Breakdown:

- Add in new `--base` option when creating a new cartridge install.
- Refactors due to the above change
- No one asked for it, but we have emoji on the prompts now 👍 
-  Changed `fileTemplater.js` to be promise based (instead of callback). I've kept in the 'onEachFile' callback functionality. As this module is only used internally, this isn't a breaking change.

All of these changes are subject to a feature / patch version bump