### PR TITLE
Feat/auto updater

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
-require('./programBuilder.js')();
+var updateNotifier = require('update-notifier');
+var pkg = require('../package.json');
+var program = require('./programBuilder.js');
+
+updateNotifier({ pkg: pkg, callback: program }).notify();

--- a/bin/programBuilder.js
+++ b/bin/programBuilder.js
@@ -1,11 +1,11 @@
 "use strict";
 
+var path = require('path');
+
 var program = require('commander');
-var path    = require('path');
-var os = require('os');
 
 var newCommand = require('./commands/new');
-var pkg        = require(path.resolve(__dirname, '..', 'package.json'));
+var pkg = require(path.resolve(__dirname, '..', 'package.json'));
 
 /**
  * Get the ball-rolling for the whole program

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "npm-registry": "^0.1.13",
     "pretty-error": "^2.0.0",
     "titleize": "^1.0.0",
-    "unzip": "^0.1.11"
+    "unzip": "^0.1.11",
+    "update-notifier": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^1.6.1",


### PR DESCRIPTION
Add in [update-notifier](https://github.com/yeoman/update-notifier) package.

This will display an screen message if the user is using a version of `cartridge-cli` that is a lower version number compared to the most recent npm release.

Fixes #14 